### PR TITLE
Upgrade helm to version 3 for the Github action workflows.

### DIFF
--- a/.github/workflows/dotnet_player_cicd.yml
+++ b/.github/workflows/dotnet_player_cicd.yml
@@ -38,7 +38,9 @@ jobs:
         resource-group: ${{ secrets.RESOURCE_GROUP }}        
     - name: Init Helm
       run: |
-        helm init --upgrade
+        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 > get_helm.sh
+        chmod 700 get_helm.sh
+        ./get_helm.sh
         az acr helm repo add -n ${{ secrets.ACR_NAME }}
     - name: Package Helm chart
       run: |

--- a/.github/workflows/game-manager_cicd.yml
+++ b/.github/workflows/game-manager_cicd.yml
@@ -38,7 +38,9 @@ jobs:
         resource-group: ${{ secrets.RESOURCE_GROUP }}        
     - name: Init Helm
       run: |
-        helm init --upgrade
+        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 > get_helm.sh
+        chmod 700 get_helm.sh
+        ./get_helm.sh
         az acr helm repo add -n ${{ secrets.ACR_NAME }}
     - name: Package Helm chart
       run: |

--- a/.github/workflows/java_player_cicd.yml
+++ b/.github/workflows/java_player_cicd.yml
@@ -38,7 +38,9 @@ jobs:
         resource-group: ${{ secrets.RESOURCE_GROUP }}        
     - name: Init Helm
       run: |
-        helm init --upgrade
+        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 > get_helm.sh
+        chmod 700 get_helm.sh
+        ./get_helm.sh
         az acr helm repo add -n ${{ secrets.ACR_NAME }}
     - name: Package Helm chart
       run: |

--- a/.github/workflows/node_player_cicd.yml
+++ b/.github/workflows/node_player_cicd.yml
@@ -38,7 +38,9 @@ jobs:
         resource-group: ${{ secrets.RESOURCE_GROUP }}        
     - name: Init Helm
       run: |
-        helm init --upgrade
+        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 > get_helm.sh
+        chmod 700 get_helm.sh
+        ./get_helm.sh
         az acr helm repo add -n ${{ secrets.ACR_NAME }}
     - name: Package Helm chart
       run: |

--- a/.github/workflows/php_player_cicd.yml
+++ b/.github/workflows/php_player_cicd.yml
@@ -38,7 +38,9 @@ jobs:
         resource-group: ${{ secrets.RESOURCE_GROUP }}        
     - name: Init Helm
       run: |
-        helm init --upgrade
+        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 > get_helm.sh
+        chmod 700 get_helm.sh
+        ./get_helm.sh
         az acr helm repo add -n ${{ secrets.ACR_NAME }}
     - name: Package Helm chart
       run: |

--- a/.github/workflows/python_player_cicd.yml
+++ b/.github/workflows/python_player_cicd.yml
@@ -38,7 +38,9 @@ jobs:
         resource-group: ${{ secrets.RESOURCE_GROUP }}        
     - name: Init Helm
       run: |
-        helm init --upgrade
+        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 > get_helm.sh
+        chmod 700 get_helm.sh
+        ./get_helm.sh
         az acr helm repo add -n ${{ secrets.ACR_NAME }}
     - name: Package Helm chart
       run: |

--- a/.github/workflows/web-cicd.yml
+++ b/.github/workflows/web-cicd.yml
@@ -43,7 +43,9 @@ jobs:
         resource-group: ${{ secrets.RESOURCE_GROUP }}        
     - name: Init Helm
       run: |
-        helm init --upgrade
+        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 > get_helm.sh
+        chmod 700 get_helm.sh
+        ./get_helm.sh
         az acr helm repo add -n ${{ secrets.ACR_NAME }}
     - name: Package Helm chart
       run: |


### PR DESCRIPTION
Currently the scripts for deployment uses Helm 3 but the workflows are using 2. This change upgrades the workflows to Helm 3.