### PR TITLE
Resolves: Add native GitHub security and versioning dependency alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # default location of `.github/workflows`
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: "nuget"
+    # location of package manifests
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: "npm"
+    # location of package manifests
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,77 +1,309 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    # default location of `.github/workflows`
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    # default location of '.github/workflows'
+    directory: '/'
     open-pull-requests-limit: 10
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
+    # target-branch: 'develop'
     # assignees:
     #   - assignee_one
     # reviewers:
     #   - reviewer_one
 
-  - package-ecosystem: "nuget"
-    # location of package manifests
-    directory: "Source/"
+  - package-ecosystem: 'composer'
+    directory: 'Source/Services/RPSLS.PHPPlayer.Api/src'
     open-pull-requests-limit: 10
     schedule:
-      interval: "daily"
+      interval: 'daily'
+    # target-branch: 'develop'
     # assignees:
     #   - assignee_one
     # reviewers:
     #   - reviewer_one
 
-  - package-ecosystem: "npm"
-    # location of package manifests
-    directory: "Source/Services/RPSLS.NodePlayer.Api/"
+  - package-ecosystem: 'docker'
+    directory: 'Source/Services/RPSLS.DotNetPlayer.Api'
     open-pull-requests-limit: 10
     schedule:
-      interval: "daily"
+      interval: 'daily'
+    # target-branch: 'develop'
     # assignees:
     #   - assignee_one
     # reviewers:
     #   - reviewer_one
 
-  - package-ecosystem: "pip"
-    # location of package manifests
-    directory: "Source/Services/RPSLS.PythonPlayer.Api/"
+  - package-ecosystem: 'docker'
+    directory: 'Source/Services/RPSLS.Game/Server'
     open-pull-requests-limit: 10
     schedule:
-      interval: "daily"
+      interval: 'daily'
+    # target-branch: 'develop'
     # assignees:
     #   - assignee_one
     # reviewers:
     #   - reviewer_one
 
-  - package-ecosystem: "pip"
-    # location of package manifests
-    directory: "Source/Functions/RPSLS.Python.Api/"
+  - package-ecosystem: 'docker'
+    directory: 'Source/Services/RPSLS.Game.Api'
     open-pull-requests-limit: 10
     schedule:
-      interval: "daily"
+      interval: 'daily'
+    # target-branch: 'develop'
     # assignees:
     #   - assignee_one
     # reviewers:
     #   - reviewer_one
 
-  - package-ecosystem: "maven"
-    # location of package manifests
-    directory: "Source/Services/RPSLS.JavaPlayer.Api/"
+  - package-ecosystem: 'docker'
+    directory: 'Source/Services/RPSLS.JavaPlayer.Api'
     open-pull-requests-limit: 10
     schedule:
-      interval: "daily"
+      interval: 'daily'
+    # target-branch: 'develop'
     # assignees:
     #   - assignee_one
     # reviewers:
     #   - reviewer_one
 
-  - package-ecosystem: "composer"
-    # location of package manifests
-    directory: "Source/Services/RPSLS.PHPPlayer.Api/src/"
+  - package-ecosystem: 'docker'
+    directory: 'Source/Services/RPSLS.ModelUploader.Web'
     open-pull-requests-limit: 10
     schedule:
-      interval: "daily"
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'docker'
+    directory: 'Source/Services/RPSLS.NodePlayer.Api'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'docker'
+    directory: 'Source/Services/RPSLS.PHPPlayer.Api'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'docker'
+    directory: 'Source/Services/RPSLS.PythonPlayer.Api'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'maven'
+    directory: 'Source/Services/RPSLS.JavaPlayer.Api'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'npm'
+    directory: 'Documents/Workshop/Step1'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'npm'
+    directory: 'Documents/Workshop/Step2'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'npm'
+    directory: 'Documents/Workshop/Step3'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'npm'
+    directory: 'Documents/Workshop/Step4'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'npm'
+    directory: 'Documents/Workshop/Step5'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'npm'
+    directory: 'Documents/Workshop/Step6'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'npm'
+    directory: 'Source/Services/RPSLS.NodePlayer.Api'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'nuget'
+    directory: 'Source'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'nuget'
+    directory: 'Source/Services/RPSLS.DotNetPlayer.Api'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'nuget'
+    directory: 'Source/Services/RPSLS.Game/Client'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'nuget'
+    directory: 'Source/Services/RPSLS.Game/Server'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'nuget'
+    directory: 'Source/Services/RPSLS.Game/Shared'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'nuget'
+    directory: 'Source/Services/RPSLS.Game.Api'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'nuget'
+    directory: 'Source/Services/RPSLS.Game.Multiplayer'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'nuget'
+    directory: 'Source/Services/RPSLS.ModelUploader.Web'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'pip'
+    directory: 'Source/Functions/RPSLS.Python.Api'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'pip'
+    directory: 'Source/Services/RPSLS.PythonPlayer.Api'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
     # assignees:
     #   - assignee_one
     # reviewers:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
-    # target-branch: 'develop'
     # assignees:
     #   - assignee_one
     # reviewers:
@@ -18,7 +17,6 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
-    # target-branch: 'develop'
     # assignees:
     #   - assignee_one
     # reviewers:
@@ -30,7 +28,6 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
-    # target-branch: 'develop'
     # assignees:
     #   - assignee_one
     # reviewers:
@@ -42,7 +39,6 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
-    # target-branch: 'develop'
     # assignees:
     #   - assignee_one
     # reviewers:
@@ -54,7 +50,6 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
-    # target-branch: 'develop'
     # assignees:
     #   - assignee_one
     # reviewers:
@@ -66,7 +61,17 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
-    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: "composer"
+    # location of package manifests
+    directory: "Source/Services/RPSLS.PHPPlayer.Api/src/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
     # assignees:
     #   - assignee_one
     # reviewers:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
 
   - package-ecosystem: "nuget"
     # location of package manifests
-    directory: "/"
+    directory: "Source/"
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
@@ -26,7 +26,43 @@ updates:
 
   - package-ecosystem: "npm"
     # location of package manifests
-    directory: "/"
+    directory: "Source/Services/RPSLS.NodePlayer.Api/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: "pip"
+    # location of package manifests
+    directory: "Source/Services/RPSLS.PythonPlayer.Api/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: "pip"
+    # location of package manifests
+    directory: "Source/Functions/RPSLS.Python.Api/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: "maven"
+    # location of package manifests
+    directory: "Source/Services/RPSLS.JavaPlayer.Api/"
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"


### PR DESCRIPTION
- add `dependabot.yml` which automatically enables Dependabot's dependency versioning scanner and dependency update PRs bot by declaring dependency ecosystems and sources in the project. For dependency security vulnerabilities scanner and vulnerable dependency update PRs bot, [enable "Dependabot alerts" and "Dependabot security updates"](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates)

- should you decide that certain people on your team should take care of the PRs that Dependabot creates, use the two attributes `assignees` and `reviewers` to automatically set personnel respectively.

Resolves #43 