### PR TITLE
Resolves: Add native GitHub continuous code security and quality analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,50 @@
+name: CodeQL Analysis
+
+on:
+  push:
+    paths:
+      - 'Source/**'
+  pull_request:
+    paths:
+      - 'Source/**'
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [ 'csharp', 'java', 'javascript', 'python' ]
+    steps:
+      - name: Checkout repository
+        id: checkout_repo
+        uses: actions/checkout@v2
+
+      - name: Initialize CodeQL
+        id: init_codeql
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          category: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - if: matrix.language == 'csharp'
+        name: Build C# code
+        id: build_csharp_code
+        uses: github/codeql-action/autobuild@v1
+
+      - if: matrix.language == 'java'
+        name: Build Java code
+        id: build_java_code
+        run: |
+          ./mvnw package
+        working-directory: Source/Services/RPSLS.JavaPlayer.Api/
+
+      - name: Perform CodeQL Analysis
+        id: analyze_codeql
+        uses: github/codeql-action/analyze@v1
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)


### PR DESCRIPTION
- add `codeql-analysis.yml` which automatically enables CodeQL code security and quality scanner. It executes on every push commit and PR with change to the source code, manually and every day at 8:00AM UTC. The pipeline runs in parallel for C#, Java, Javascript and Python (unfortunately CodeQL doesn't support PHP, yet). A scan check can be viewed on commits and PRs. All alerts and fix suggestion can be viewed at **Security** tab -> **Code scanning alerts** -> **CodeQL**

Resolves #45 